### PR TITLE
R7 json api

### DIFF
--- a/api.py
+++ b/api.py
@@ -82,10 +82,10 @@ class MemberListAPI(webapp2.RequestHandler):
 		if not check_authentication(self):
 			return
 		
-		# Get all users from the given semester
+		# Get all users from the given semester.
 		selected_semester = self.request.get('semester')
 
-		# By default only grab members who have paid and wish to be listed publicly
+		# By default only grab members who have paid and wish to be listed publicly.
 		show_all = self.request.get('all')
 		if show_all:
 			if show_all.lower() == 'true':
@@ -95,7 +95,7 @@ class MemberListAPI(webapp2.RequestHandler):
 		else: 
 			show_all = False
 
-		# If ID is specified as a parameter, only provide one member in the output, filtered by that ID
+		# If ID is specified as a parameter, only provide one member in the output, filtered by that ID.
 		member_id = self.request.get('id')
 		if member_id:
 			member = Member.query(Member.id == member_id).get()
@@ -133,7 +133,7 @@ class RankAPI(webapp2.RequestHandler):
 
 		member = Member.query(Member.id == id).get()
 		if not member:
-			# 404 if a nonexistent member is specified
+			# Throw 404 if a nonexistent member is specified.
 			self.error(404)
 			return
 
@@ -142,17 +142,17 @@ class RankAPI(webapp2.RequestHandler):
 		if not selected_semester:
 			selected_semester = get_current_semester()
 		else:
-			# Avoid throwing error 500 if a bad semester string is supplied
+			# Avoid throwing error 500 if a bad semester string is supplied.
 			try:
 				selected_semester = float(selected_semester)
 			except ValueError:
 				self.error(400)
 				return
-		#Build output dict with all rank related results
+		# Build output dict with all rank related results.
 		output = {
-		'rankName': member.get_rank_name(selected_semester),
-		'rankDisp': member.get_rank_disp(selected_semester),
-		'rankWithName': member.get_name_with_rank(selected_semester)}
+		'name': member.get_rank_name(selected_semester),
+		'disp': member.get_rank_disp(selected_semester),
+		'rankName': member.get_name_with_rank(selected_semester)}
 
 
 		self.response.headers['Content-Type'] = 'application/json'
@@ -165,9 +165,9 @@ class MissionListAPI(webapp2.RequestHandler):
 		
 		selected_semester = self.request.get('semester')
 
-		# Offer option to filter by a semester, but by default just send all missions
+		# Offer option to filter by a semester, but by default just send all missions.
 		if selected_semester:
-			# Avoid throwing error 500 if a bad semester string is supplied
+			# Avoid throwing error 500 if a bad semester string is supplied.
 			try:
 				selected_semester = float(selected_semester)
 			except ValueError:
@@ -190,14 +190,14 @@ class MissionAPI(webapp2.RequestHandler):
 			return
 
 		if not id:
-			# Error if no mission specified
+			# Throw 400 if no mission specified.
 			self.error(400)
 			return
 
 		mission = Mission.query(Mission.id == id).get()
 
 		if not mission:
-			# Error if mission not found
+			# Throw 404 if mission not found.
 			self.error(404)
 			return
 
@@ -222,7 +222,7 @@ class BridgeCrewAPI(webapp2.RequestHandler):
 		if not check_authentication(self):
 			return
 
-		# Only link latest bridge crew for now, don't see a reason to send anything besides the current one or all of them
+		# Only link latest bridge crew for now, don't see a reason to send anything besides the current one or all of them.
 		if crew == 'current':
 			bridgecrew = BridgeCrew.query().order(-BridgeCrew.start).get()
 		else:

--- a/api.py
+++ b/api.py
@@ -144,17 +144,12 @@ class RankAPI(webapp2.RequestHandler):
 			except ValueError:
 				self.error(400)
 				return
-		
-		if rank_type == 'name':
-			output = member.get_rank_name(selected_semester)
-		elif rank_type == 'disp':
-			output = member.get_rank_disp(selected_semester)
-		elif rank_type == 'with_name':
-			output = member.get_name_with_rank(selected_semester)
-		else: 
-			# 400 if no known rank type is passed
-			self.error(404)
-			return
+		#Build output dict with all rank related results	
+		output = {
+		'rankName': member.get_rank_name(selected_semester),
+		'rankDisp': member.get_rank_disp(selected_semester),
+		'rankWithName': member.get_name_with_rank(selected_semester)}
+
 
 		self.response.headers['Content-Type'] = 'application/json'
 		self.response.write(json.dumps(output))

--- a/api.py
+++ b/api.py
@@ -92,9 +92,9 @@ class MemberListAPI(webapp2.RequestHandler):
 			except ValueError:
 				self.error(400)
 				return
-			members = Member.query(Member.show == True, Member.semesters_paid == selected_semester).order(Member.name).fetch(limit=None)
+			members = Member.query(Member.semesters_paid == selected_semester).order(Member.name).fetch(limit=None)
 		else:
-			members = Member.query(Member.show == True, Member.never_paid == False).order(Member.name).fetch(limit=None)
+			members = Member.query().order(Member.name).fetch(limit=None)
 		
 		output = [format_member(member) for member in members]
 		

--- a/api.py
+++ b/api.py
@@ -84,6 +84,16 @@ class MemberListAPI(webapp2.RequestHandler):
 		
 		# Get all users from the given semester
 		selected_semester = self.request.get('semester')
+
+		# By default only grab members who have paid and wish to be listed publicly
+		show_all = self.request.get('all')
+		if show_all:
+			if show_all.lower() == 'true':
+				show_all = True
+			else: 
+				show_all = False
+		else: 
+			show_all = False
 		
 		if selected_semester:
 			# Avoid throwing error 500 if a bad semester string is supplied.
@@ -92,9 +102,17 @@ class MemberListAPI(webapp2.RequestHandler):
 			except ValueError:
 				self.error(400)
 				return
-			members = Member.query(Member.semesters_paid == selected_semester).order(Member.name).fetch(limit=None)
+			if show_all: 
+				members = Member.query(Member.semesters_paid == selected_semester).order(Member.name).fetch(limit=None)
+			else:
+				members = Member.query(Member.semesters_paid == selected_semester, Member.never_paid == False, Member.show == True).order(Member.name).fetch(limit=None)
+
 		else:
-			members = Member.query().order(Member.name).fetch(limit=None)
+			if show_all:
+				members = Member.query().order(Member.name).fetch(limit=None)
+			else:
+				members = Member.query(Member.never_paid == False, Member.show == True).order(Member.name).fetch(limit=None)
+
 		
 		output = [format_member(member) for member in members]
 		

--- a/api.py
+++ b/api.py
@@ -86,7 +86,7 @@ class MemberListAPI(webapp2.RequestHandler):
 		selected_semester = self.request.get('semester')
 		
 		if selected_semester:
-			# Avoid throwing error 500 if a bad semester string is supplied
+			# Avoid throwing error 500 if a bad semester string is supplied.
 			try:
 				selected_semester = float(selected_semester)
 			except ValueError:
@@ -123,7 +123,7 @@ class MemberAPI(webapp2.RequestHandler):
 		self.response.write(json.dumps(output))
 
 class RankAPI(webapp2.RequestHandler):
-	def get(self, rank_type, id):
+	def get(self, id):
 		if not check_authentication(self):
 			return
 
@@ -144,7 +144,7 @@ class RankAPI(webapp2.RequestHandler):
 			except ValueError:
 				self.error(400)
 				return
-		#Build output dict with all rank related results	
+		#Build output dict with all rank related results
 		output = {
 		'rankName': member.get_rank_name(selected_semester),
 		'rankDisp': member.get_rank_disp(selected_semester),
@@ -238,7 +238,7 @@ class APIFail(webapp2.RequestHandler):
 app = webapp2.WSGIApplication([
 	('/api/members/?', MemberListAPI),
 	('/api/member/([a-z0-9]+)', MemberAPI),
-	('/api/rank/([a-z_]+)/([a-zA-Z0-9]+)', RankAPI),
+	('/api/rank/([a-zA-Z0-9]+)', RankAPI),
 	('/api/missions/?', MissionListAPI),
 	('/api/mission/([a-z0-9]+)', MissionAPI),
 	('/api/bridgecrews/?', BridgeCrewListAPI),

--- a/api.py
+++ b/api.py
@@ -24,37 +24,37 @@ def format_member(member):
 		'show': member.show,
 		'name': member.name,
 		'dce': member.dce,
-		'mailing_list': member.mailing_list,
-		'current_student': member.current_student,
+		'mailingList': member.mailing_list,
+		'currentStudent': member.current_student,
 		'email': member.email,
-		'semesters_paid': member.semesters_paid,
-		'mission_ids': member.mission_ids,
-		'committee_rank': member.committee_rank,
-		'merit_rank1': member.merit_rank1,
-		'merit_rank2': member.merit_rank2,
-		'card_color': member.card_color,
-		'card_emblem': member.card_emblem,
-		'card_printed': member.card_printed
+		'semestersPaid': member.semesters_paid,
+		'missionIds': member.mission_ids,
+		'committeeRank': member.committee_rank,
+		'meritRank1': member.merit_rank1,
+		'meritRank2': member.merit_rank2,
+		'cardColor': member.card_color,
+		'cardEmblem': member.card_emblem,
+		'cardPrinted': member.card_printed
 	}
 
 def format_mission(mission):
 	return {
 		'id': mission.id,
 		'type': mission.type,
-		'type_name': mission.type_name,
+		'typeName': mission.type_name,
 		'title': mission.title,
 		'description': mission.description,
-		'html_description': mission.html_description,
+		'htmlDescription': mission.html_description,
 		'start': mission.start_str,
 		'end': mission.end_str,
 		'location': mission.location,
 		'runners': mission.runners,
-		'wave_url': mission.wave_url,
-		'drive_url': mission.drive_url,
-		'fb_url': mission.fb_url,
-		'gplus_url': mission.gplus_url,
-		'the_link_url': mission.the_link_url,
-		'youtube_url': mission.youtube_url
+		'waveUrl': mission.wave_url,
+		'driveUrl': mission.drive_url,
+		'fbUrl': mission.fb_url,
+		'gplusUrl': mission.gplus_url,
+		'theLinkUrl': mission.the_link_url,
+		'youtubeUrl': mission.youtube_url
 	}
 
 def format_bridgecrew(crew):
@@ -64,7 +64,7 @@ def format_bridgecrew(crew):
 		'end': str(crew.end),
 		'admiral': crew.admiral,
 		'captain': crew.captain,
-		'first_officer': crew.first_officer,
+		'firstOfficer': crew.first_officer,
 		'ops': crew.ops,
 		'comms': crew.comms,
 		'engi': crew.engi,

--- a/api.py
+++ b/api.py
@@ -68,6 +68,12 @@ class MemberListAPI(webapp2.RequestHandler):
 		selected_semester = self.request.get('semester')
 		
 		if selected_semester:
+			# Avoid throwing error 500 if a bad semester string is supplied
+			try:
+				selected_semester = float(selected_semester)
+			except ValueError:
+				self.error(400)
+				return
 			members = Member.query(Member.show == True, Member.semesters_paid == selected_semester).order(Member.name).fetch(limit=None)
 		else:
 			members = Member.query(Member.show == True, Member.never_paid == False).order(Member.name).fetch(limit=None)
@@ -120,16 +126,26 @@ class RankAPI(webapp2.RequestHandler):
 			self.error(404)
 			return
 
-		semester = self.request.get('semester')
-
+		selected_semester = self.request.get('semester')
+		
+		if not selected_semester:
+			selected_semester = get_current_semester()
+		else:
+			# Avoid throwing error 500 if a bad semester string is supplied
+			try:
+				selected_semester = float(selected_semester)
+			except ValueError:
+				self.error(400)
+				return
+		
 		if not rank_type:
-			output = member.get_rank(semester)
+			output = member.get_rank(selected_semester)
 		elif rank_type == 'name':
-			output = member.get_rank_name(semester)
+			output = member.get_rank_name(selected_semester)
 		elif rank_type == 'disp':
-			output = member.get_rank_disp(semester)
+			output = member.get_rank_disp(selected_semester)
 		elif rank_type == 'with_name':
-			output = member.get_name_with_rank(semester)
+			output = member.get_name_with_rank(selected_semester)
 		else: 
 			# 400 if no known rank type is passed
 			self.error(404)
@@ -147,6 +163,12 @@ class MissionListAPI(webapp2.RequestHandler):
 
 		# Offer option to filter by a semester, but by default just send all missions
 		if selected_semester:
+			# Avoid throwing error 500 if a bad semester string is supplied
+			try:
+				selected_semester = float(selected_semester)
+			except ValueError:
+				self.error(400)
+				return
 			next_semester_date = semester_date(next_semester(selected_semester))
 			selected_semester_date = semester_date(selected_semester)
 			missions = Mission.query(Mission.start >= selected_semester_date, Mission.start < next_semester_date).fetch(limit=None)

--- a/api.py
+++ b/api.py
@@ -28,7 +28,8 @@ def format_member(member):
 		'currentStudent': member.current_student,
 		'email': member.email,
 		'semestersPaid': member.semesters_paid,
-		'missionIds': member.mission_ids,
+		'missionIds': [mission.id for mission in Mission.query(
+			Mission.runners == member.id).order(Mission.start).fetch(limit=None)],
 		'committeeRank': member.committee_rank,
 		'meritRank1': member.merit_rank1,
 		'meritRank2': member.merit_rank2,
@@ -57,7 +58,7 @@ def format_mission(mission):
 		'youtubeUrl': mission.youtube_url
 	}
 
-def format_bridgecrew(crew):
+def format_bridge_crew(crew):
 	return {
 		'yearStr': crew.year_str,
 		'start': str(crew.start),
@@ -210,9 +211,9 @@ class BridgeCrewListAPI(webapp2.RequestHandler):
 	def get(self):
 		if not check_authentication(self):
 			return
-		bridgecrews = BridgeCrew.query().fetch(limit=None)
+		bridge_crews = BridgeCrew.query().fetch(limit=None)
 
-		output = [format_bridgecrew(crew) for crew in bridgecrews]
+		output = [format_bridge_crew(crew) for crew in bridgecrews]
 
 		self.response.headers['Content-Type'] = 'application/json'
 		self.response.write(json.dumps(output))
@@ -224,12 +225,12 @@ class BridgeCrewAPI(webapp2.RequestHandler):
 
 		# Only link latest bridge crew for now, don't see a reason to send anything besides the current one or all of them.
 		if crew == 'current':
-			bridgecrew = BridgeCrew.query().order(-BridgeCrew.start).get()
+			bridge_crew = BridgeCrew.query().order(-BridgeCrew.start).get()
 		else:
 			self.error(404)
 			return
 
-		output = format_bridgecrew(bridgecrew)
+		output = format_bridge_crew(bridgecrew)
 
 		self.response.headers['Content-Type'] = 'application/json'
 		self.response.write(json.dumps(output))
@@ -243,8 +244,8 @@ app = webapp2.WSGIApplication([
 	('/api/members/?', MemberListAPI),
 	('/api/rank/([a-zA-Z0-9]+)', RankAPI),
 	('/api/missions/?', MissionListAPI),
-	('/api/mission/([a-z0-9]+)', MissionAPI),
+	('/api/mission/([a-zA-Z0-9]+)', MissionAPI),
 	('/api/bridgecrews/?', BridgeCrewListAPI),
-	('/api/bridgecrew/([a-z0-9]+)?', BridgeCrewAPI),
+	('/api/bridgecrew/([a-zA-Z0-9]+)?', BridgeCrewAPI),
 	('/api/?(\?.*)?', APIFail)
 ])

--- a/models.py
+++ b/models.py
@@ -41,6 +41,10 @@ class Member(ndb.Model):
 	
 	def get_missions(self):
 		return Mission.query(Mission.runners == self.id).order(Mission.start).fetch(limit=None)
+
+	def get_mission_ids(self):
+		missions = Mission.query(Mission.runners == self.id).order(Mission.start).fetch(limit=None)
+		return [mission.id for mission in missions]
 	
 	def get_rank(self, semester=get_current_semester()):
 		from ranks import rank
@@ -87,6 +91,7 @@ class Member(ndb.Model):
 		#return 'data:image/svg+xml;base64,' + base64.b64encode(qr.make_svg())
 	
 	missions = property(get_missions)
+	mission_ids = property(get_mission_ids)
 	
 	def _post_put_hook(self, future):
 		# Generate the member's QR code if the member does not have one.

--- a/models.py
+++ b/models.py
@@ -42,10 +42,6 @@ class Member(ndb.Model):
 	def get_missions(self):
 		return Mission.query(Mission.runners == self.id).order(Mission.start).fetch(limit=None)
 
-	def get_mission_ids(self):
-		missions = Mission.query(Mission.runners == self.id).order(Mission.start).fetch(limit=None)
-		return [mission.id for mission in missions]
-	
 	def get_rank(self, semester=get_current_semester()):
 		from ranks import rank
 		if not semester:
@@ -91,7 +87,6 @@ class Member(ndb.Model):
 		#return 'data:image/svg+xml;base64,' + base64.b64encode(qr.make_svg())
 	
 	missions = property(get_missions)
-	mission_ids = property(get_mission_ids)
 	
 	def _post_put_hook(self, future):
 		# Generate the member's QR code if the member does not have one.


### PR DESCRIPTION
Resolves #38. 

Implemented more complete read only JSON api. There is capability to read a full list or single selection from bridge crews, members, and missions. Ranks have also been separated out under `/api/rank/<rank_type>/<member_id>` to avoid calculating them unless the information is explicitly requested. 

There is capability through this to read every static element of the datastore, except for member QR codes (they wouldn't format easily to text). Every endpoint requires a valid apiKey, and the lists support semester-based filtering. 